### PR TITLE
Removed Album subdirectory

### DIFF
--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -135,7 +135,7 @@ def __stripPath__(path):
 
 # "{ArtistName}/{Flag} [{AlbumID}] [{AlbumYear}] {AlbumTitle}"
 def __getAlbumPath__(conf: Settings, album):
-    base = conf.downloadPath + '/Album/'
+    base = conf.downloadPath
     artist = aigpy.path.replaceLimitChar(album.artists[0].name, '-')
     # album folder pre: [ME][ID]
     flag = API.getFlag(album, Type.Album, True, "")


### PR DESCRIPTION
Removed album subdirectory as the configuration allows the user to set the directory as desired. I see no reason to have a hardcoded subdirectory.